### PR TITLE
Add http method | Fixes #2

### DIFF
--- a/bin/ncbi-blast-dbs
+++ b/bin/ncbi-blast-dbs
@@ -7,6 +7,14 @@ trap :INT do
   exit!
 end
 
-Rake.application.init 'ncbi-blast-dbs'
-Rake.application.load_imports
-Rake.application.top_level
+if ARGV.include? "http";
+  import "#{File.dirname(__FILE__)}/../lib/http-ncbi-blast-dbs.rake"
+  Rake.application.init 'http-ncbi-blast-dbs'
+  Rake.application.load_imports
+  Rake.application.top_level  
+else;
+  import "#{File.dirname(__FILE__)}/../lib/ncbi-blast-dbs.rake"
+  Rake.application.init 'ncbi-blast-dbs'
+  Rake.application.load_imports
+  Rake.application.top_level
+end

--- a/bin/ncbi-blast-dbs
+++ b/bin/ncbi-blast-dbs
@@ -1,7 +1,6 @@
 #!/usr/bin/env ruby
 
 require 'rake'
-import "#{File.dirname(__FILE__)}/../lib/ncbi-blast-dbs.rake"
 
 trap :INT do
   puts "Quitting ..."

--- a/lib/http-ncbi-blast-dbs.rake
+++ b/lib/http-ncbi-blast-dbs.rake
@@ -66,17 +66,17 @@ databases.each do |name, files|
   multitask(name => files.map { |file| task(file) { download(file, last.values.uniq) } })
 end
 
-# Taxonomy database is different from sequence databases.
-# task :taxdump do
-#   download 'ftp://ftp.ncbi.nih.gov/pub/taxonomy/taxdump.tar.gz'
-# end
-
 # List name of all databases that can be downloaded if executed without
 # any arguments.
 task :default do
   databases
   puts databases.keys.push('taxdump').join(', ')
 end
+
+task :taxdump do
+  download('https://ftp.ncbi.nih.gov/pub/taxonomy/taxdump.tar.gz', "nil")
+end
+
 # Ruby being over my head, this is my quick-and-dirty way to trick it ignoring
 # "http" as a task rather than a specification. Happy for an expert to fix it up!
 task :http do

--- a/lib/http-ncbi-blast-dbs.rake
+++ b/lib/http-ncbi-blast-dbs.rake
@@ -25,6 +25,7 @@ def download(url, last_to_do)
     elsif file == last_to_do;
       sh "tar xfov #{file}"      
     else
+      # at least nr and nt tarballs have identical files .?al; unsure of others
       sh "tar xfov #{file} --exclude='*.?al' --exclude='taxdb*'"
     end
   end
@@ -49,6 +50,7 @@ def databases
     array_of_files.append(filenames_and_newlines) unless filenames_and_newlines.nil?
   end
 
+  # append the full path to file for downstream wget
   array_of_files.map! { |string| "".concat("/blast/db/", string ) }
   array_of_files.
     map { |file| File.join(host, file) }.

--- a/lib/http-ncbi-blast-dbs.rake
+++ b/lib/http-ncbi-blast-dbs.rake
@@ -41,6 +41,10 @@ def databases
 
   array_of_files = []
   body.each do |line|
+    # regex takes the raw http response, matches lines such as:
+    #    href="tsa_nt.06.tar.gz.md5">tsa_nt.06.tar.gz</a>
+    # Returns:
+    # tsa_nt.06.tar.gz
     filenames_and_newlines = line[/(^href=".*">)(.*tar.gz|.*md5)(<\/a>)$/, 2]
     array_of_files.append(filenames_and_newlines) unless filenames_and_newlines.nil?
   end

--- a/lib/http-ncbi-blast-dbs.rake
+++ b/lib/http-ncbi-blast-dbs.rake
@@ -1,0 +1,78 @@
+require 'net/http'
+require 'uri'
+puts "using http-ncbi-dbs-dgs.rake"
+# Downloads tarball at the given URL if a local copy does not exist, or if the
+# local copy is older than at the given URL, or if the local copy is corrupt.
+def download(url, last_to_do)
+  file = File.basename(url)
+
+  # # Resume an interrupted download or fetch the file for the first time. If
+  # # the file on the server is newer, then it is downloaded from start.
+
+  sh "wget -Nc --no-verbose #{url}"
+  # If the local copy is already fully retrieved, then the previous command
+  # ignores the timestamp. So we check with the server again if the file on
+  # the server is newer and if so download the new copy.
+  sh "wget -N --no-verbose #{url}"
+  sh "wget -Nc --no-verbose #{url}.md5"
+  sh "wget -N --no-verbose #{url}.md5"
+  # Immediately download md5 and verify the tarball. Re-download tarball if
+  # corrupt; extract otherwise.
+  sh "md5sum -c #{file}.md5" do |matched, _|
+    if !matched
+      sh "rm #{file} #{file}.md5"; download(url)
+    # too many tar instances unzipping the same file clutter the system
+    elsif file == last_to_do;
+      sh "tar xfov #{file}"      
+    else
+      sh "tar xfov #{file} --exclude='*.?al' --exclude='taxdb*'"
+    end
+  end
+end
+
+
+def databases
+  method = 'https://'
+  host, dir = 'ftp.ncbi.nlm.nih.gov', 'blast/db'
+  uri = URI.parse(method + host + "/" + dir + "/")
+
+  response = Net::HTTP.get_response(uri)
+  body = response.body.split
+
+  array_of_files = []
+  body.each do |line|
+    filenames_and_newlines = line[/(^href=".*">)(.*tar.gz|.*md5)(<\/a>)$/, 2]
+    array_of_files.append(filenames_and_newlines) unless filenames_and_newlines.nil?
+  end
+
+  array_of_files.map! { |string| "".concat("/blast/db/", string ) }
+  array_of_files.
+    map { |file| File.join(host, file) }.
+    select { |file| file.match(/\.tar\.gz$/) }.
+    group_by { |file| File.basename(file).split('.')[0] }
+end
+
+
+# Create user-facing task for each database to drive the download of its
+# volumes in parallel.
+databases.each do |name, files|
+  last = { name => files.last }
+  multitask(name => files.map { |file| task(file) { download(file, last.values.uniq) } })
+end
+
+# Taxonomy database is different from sequence databases.
+# task :taxdump do
+#   download 'ftp://ftp.ncbi.nih.gov/pub/taxonomy/taxdump.tar.gz'
+# end
+
+# List name of all databases that can be downloaded if executed without
+# any arguments.
+task :default do
+  databases
+  puts databases.keys.push('taxdump').join(', ')
+end
+# Ruby being over my head, this is my quick-and-dirty way to trick it ignoring
+# "http" as a task rather than a specification. Happy for an expert to fix it up!
+task :http do
+  puts "using http method"
+end


### PR DESCRIPTION
For those unable to use FTP for firewall or system admin reasons, this update should work as a rough draft to enable HTTP using Ruby's net/http library. The main section that required changes were how the "databases" function parsed the remote NCBI website; once adapted to the net/http method, dealing with the response required some additional manipulation to return the same information as the original FTP method.
Secondly, perhaps as a consequence of nodes with a high number of threads, the changes to the download function should prevent tar and gzip from failing. At least two files in at least nr and nt tarballs are identical across all 70+ files, and uncompressing the same file to the same location overwhelms tar and gzip, at least on the 96 thread system I had available to test (the smallest I have at my disposal). Therefore, I excluded these two files (one ending in .?al and the other starting taxdb*) from all but the "last" tarball, inelegantly chosen from the ".last.uniq" method (https://stackoverflow.com/questions/7749131).
I've tested it on nr, nt, and taxdump, but have not been able to try all other databases.
Including "http" in the command line when running the script uses the new http-ncbi-dbs-dgs.rake. For example:
`ncbi-blast-dbs nr http`
downloads nr using the new Rakefile.
As Ruby is not my strongest programming language, there's no doubt many ways of improving these changes, which I welcome!
Thanks for this awesome script, and I hope this proves useful to you and others. Downloading these databases works so much better with your script than other options!