### PR TITLE
Use mac's md5 if md5sum is not available

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,19 +8,12 @@ or re-downloaded if corrupt. Aborted downloads are safely resumed.
 
 `ncbi-blast-dbs` is faster than NCBI's `update_blastdb.pl`. But unlike
 `update_blastdb.pl`, which is a pure Perl script, `ncbi-blast-dbs` delegates
-download and checksum verification to `wget` and `md5sum` and is thus not as
-universal.
+download and checksum verification to `wget` and `md5sum` / `md5` and is thus
+not as universal.
 
 ### Installation
 
     gem install ncbi-blast-dbs
-
-#### Note for macOS users
-
-If `md5sum` command is not present, you can install it using
-[`Homebrew`](https://brew.sh):
-
-    brew install md5sha1sum
 
 ### Usage
 


### PR DESCRIPTION
Came across a never-ending loop - where it deleted the tared file (because of md5sum not being available) and kept on redownloading the file. 

As such, put together this quick fix.

It now supports mac's `md5` (#4) - and gets around the issue that `md5` does not have `-c`.

Can you also please release a new gem to rubygems as GeneValidator uses the gem. (The last few commits are not included in the currently released gem)